### PR TITLE
Add simple ci through travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/settings.json
 **/.vscode
 *.yml
+!.travis.yml
 docker-compose.yml
 data/*
 Makefile-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+language: c
+
+services:
+  - docker
+
+script:
+- make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: c
 
 services:
-  - docker
+- docker
 
 script:
 - make build-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
   - docker
 
 script:
-- make build
+- make build-all


### PR DESCRIPTION
relates to https://github.com/zokradonh/kopano-docker/issues/26

currently only makes sure that all images are actually building, still needs verification of the build result.