### PR TITLE
External proxy setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,10 @@ if [ ! -e ./.env ]; then
 	FQDN=${new_value:-$value_default}
 
 	value_default="self_signed"
-	read -p "Email address to use for Lets Encrypt. Use 'self_signed' as your email to create self signed certificates [$value_default]: " new_value
+	read -p "Email address to use for Lets Encrypt.
+	Use 'self_signed' as your email to create self signed certificates.
+	Use 'off' if you want to run the service without tls encryption. Make sure to use an ssl-terminating reverse proxy in front in this case.
+	[$value_default]: " new_value
 	EMAIL=${new_value:-$value_default}
 
 	# Let Kapi accept self signed certs if required

--- a/web/wrapper.sh
+++ b/web/wrapper.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$EMAIL" = "self_signed" ]; then
+if [ "$EMAIL" = "self_signed" ] || [ "$EMAIL" = "off" ]; then
 	# do not use the '-host' option if using a self signed cert
 	exec kwebd caddy -conf /etc/kweb.cfg -agree
 else


### PR DESCRIPTION
handles the problems described in https://github.com/zokradonh/kopano-docker/issues/79

Idea:
Use the tls caddy config via setup.sh to optionally disable tls, which is useful when runned behind ssl-terminating reverse proxy.