### PR TITLE
enable proxy mode for self service

### DIFF
--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -51,7 +51,7 @@ services:
       - web-net
 
   password-self-service:
-    image: tiredofit/self-service-password:3.0
+    image: tiredofit/self-service-password:3.0.1
     container_name: password-self-service
     domainname: ${FQDN}
     depends_on:

--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -53,7 +53,7 @@ services:
   password-self-service:
     image: tiredofit/self-service-password:3.0
     container_name: password-self-service
-    domainname: ${LDAP_DOMAIN}
+    domainname: ${FQDN}
     depends_on:
       - ldap
       - mail
@@ -80,6 +80,7 @@ services:
       - PASSWORD_MIN_DIGIT=${SELF_SERVICE_PASSWORD_MIN_DIGIT}
       - PASSWORD_MIN_SPECIAL=${SELF_SERVICE_PASSWORD_MIN_SPECIAL}
       - PASSWORD_HASH=CRYPT
+      - IS_BEHIND_PROXY=true
     expose:
       - "80"
     networks:


### PR DESCRIPTION
i am discussing the correct creation of urls in the mail send by the self-service here:
https://github.com/tiredofit/docker-self-service-password/issues/11

necessary fixes are collected in this pull-request