### PR TITLE
Improve support on CentOS

### DIFF
--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -7,16 +7,25 @@ services:
     restart: always
     ports:
       - "2015:2015"
-      - "${HTTP}:8080"
-      - "${HTTPS}:8443"
+      - "${HTTP}:80"
+      - "${HTTPS}:443"
     environment:
       - EMAIL=${EMAIL}
       - FQDN=${FQDN}
     command: wrapper.sh
+    cap_drop:
+     - ALL
+    cap_add: 
+     - NET_BIND_SERVICE
+     - CHOWN
+     - SETGID
+     - SETUID
     volumes:
       - web:/.kweb
     networks:
-      - web-net
+      web-net:
+        aliases:
+         - ${FQDN}
 
   ldap:
     image: ${docker_repo:?err}/kopano_ldap_demo
@@ -209,8 +218,7 @@ services:
     networks:
       - kopano-net
       - ldap-net
-    extra_hosts:
-      - ${EXTRAHOSTS}
+      - web-net
     volumes:
       - kopanodata/:/kopano/data
       - kopanossl/:/kopano/ssl
@@ -270,8 +278,6 @@ services:
       - KCCONF_KAPID_LOG_LEVEL=DEBUG
       - KCCONF_KAPID_OIDC_ISSUER_IDENTIFIER=https://${FQDN}
       - KCCONF_KAPID_INSECURE=${INSECURE}
-    extra_hosts:
-      - ${EXTRAHOSTS}
     networks:
       - kopano-net
       - web-net
@@ -388,8 +394,6 @@ services:
      - oidc_issuer_identifier=https://${FQDN}
     volumes:
      - kopanossl/:/kopano/ssl
-    extra_hosts:
-     - ${EXTRAHOSTS}
     networks:
      - web-net
 

--- a/setup.sh
+++ b/setup.sh
@@ -117,11 +117,6 @@ if [ ! -e ./.env ]; then
 	read -p "FQDN to be used (for reverse proxy) [$value_default]: " new_value
 	FQDN=${new_value:-$value_default}
 
-	LOCALIP=$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')
-	value_default="$LOCALIP"
-	read -p "IP of your primary network interface (used to ensure to always resolve the FQDN) [$value_default]: " new_value
-	FQDNIP=${new_value:-$value_default}
-
 	value_default="self_signed"
 	read -p "Email address to use for Lets Encrypt.
 	Use 'self_signed' as your email to create self signed certificates.
@@ -318,7 +313,6 @@ HTTPS=443
 LDAPPORT=389
 
 # Settings for test environments
-EXTRAHOSTS=$FQDN:$FQDNIP
 INSECURE=$INSECURE
 
 # Docker Repository to push to/pull from

--- a/ssl/start.sh
+++ b/ssl/start.sh
@@ -33,6 +33,7 @@ signkey="/kopano/ssl/konnectd-tokens-signing-key.pem"
 if [ ! -f $signkey ]; then
 	echo "creating new token signing key"
 	openssl genpkey -algorithm RSA -out $signkey.tmp -pkeyopt rsa_keygen_bits:4096
+	chmod go+r $signkey.tmp
 	mv $signkey.tmp $signkey
 fi
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,6 +3,9 @@ FROM kopano/kwebd:${CODE_VERSION}
 ARG CODE_VERSION
 ENV CODE_VERSION="${CODE_VERSION}"
 
+ENV KWEBD_USER root
+ENV KWEBD_GROUP root
+USER root
 COPY wrapper.sh /usr/local/bin
 COPY kweb.cfg /etc/kweb.cfg
 

--- a/web/kweb.cfg
+++ b/web/kweb.cfg
@@ -1,8 +1,8 @@
-:8080 {
+:80 {
     redir / https://{host}{uri}
 }
 
-*, :8443 {
+*, :443 {
     log stdout
     errors stdout
 


### PR DESCRIPTION
Docker on CentOS (7) seems be behave quite different to how it does on Debian and Ubuntu. Since there is no route from the docker bridge to the original interface EXTRA_HOSTS does not work and the web container needed to be changed to directly resolve to the FQDN and listen on privileged ports.

Fixes #88