### PR TITLE
Unignore compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .vscode/settings.json
 **/.vscode
-*.yml
-*.yml-*
 !.travis.yml
-docker-compose.yml
+.travis/config.yml
 data/*
-Makefile-env
 .env
+*.env

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ KOPANO_ZPUSH_REPOSITORY_URL := http://repo.z-hub.io/z-push:/final/Debian_9.0/
 RELEASE_KEY_DOWNLOAD := 0
 DOWNLOAD_COMMUNITY_PACKAGES := 1
 
+COMPOSE_FILE := docker-compose.yml
 -include .env
 export
 
@@ -190,18 +191,18 @@ publish-zpush: build-zpush tag-zpush
 	component=zpush make publish-container
 
 test:
-	docker-compose down -v || true
+	docker-compose -f $(COMPOSE_FILE) down -v || true
 	make build-all
-	docker-compose build
-	docker-compose up -d
-	docker-compose ps
+	docker-compose -f $(COMPOSE_FILE) build
+	docker-compose -f $(COMPOSE_FILE) up -d
+	docker-compose -f $(COMPOSE_FILE) ps
 
 test-quick:
-	docker-compose stop || true
-	docker-compose up -d
-	docker-compose ps
+	docker-compose -f $(COMPOSE_FILE) stop || true
+	docker-compose -f $(COMPOSE_FILE) up -d
+	docker-compose -f $(COMPOSE_FILE) ps
 
 test-stop:
-	docker-compose stop || true
+	docker-compose -f $(COMPOSE_FILE) stop || true
 
 default: build-all

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ KOPANO_ZPUSH_REPOSITORY_URL := http://repo.z-hub.io/z-push:/final/Debian_9.0/
 RELEASE_KEY_DOWNLOAD := 0
 DOWNLOAD_COMMUNITY_PACKAGES := 1
 
-COMPOSE_FILE := docker-compose.yml-example
 -include .env
 export
 
@@ -191,18 +190,18 @@ publish-zpush: build-zpush tag-zpush
 	component=zpush make publish-container
 
 test:
-	docker-compose -f $(COMPOSE_FILE) down -v || true
+	docker-compose down -v || true
 	make build-all
-	docker-compose -f $(COMPOSE_FILE) build
-	docker-compose -f $(COMPOSE_FILE) up -d
-	docker-compose -f $(COMPOSE_FILE) ps
+	docker-compose build
+	docker-compose up -d
+	docker-compose ps
 
 test-quick:
-	docker-compose -f $(COMPOSE_FILE) stop || true
-	docker-compose -f $(COMPOSE_FILE) up -d
-	docker-compose -f $(COMPOSE_FILE) ps
+	docker-compose stop || true
+	docker-compose up -d
+	docker-compose ps
 
 test-stop:
-	docker-compose -f $(COMPOSE_FILE) stop || true
+	docker-compose stop || true
 
 default: build-all

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `docker-compose.yml` file by default pulls Docker containers from https://hu
 
 ## Updating
 
-Previously the `docker-compose.yml` file was not part of the git repository, which made it harder for users to pick and apply changes in the upstreamed `docker-compose.yml-example` file. This has meanwhile been changed and a `git pull` will now pull changes directly into `docker-compose.yml`. If you need to configure additional env variables, this can now be done in the additional env files (more details further below, for example for `kopano_server` this file is called `kopano_server.env`). If you only want to run a subset of containers it is recommended to create a copy of `docker-compose.yml` and specify your copy when running. e.g. like ´docker-compose -f my-setup.yml up -d´.
+The used `docker-compose.yml` is part of the git versioning. Which mean all changes in this repository will also be applied to your local data once you pull in the latest version. If you need to configure additional env variables, this can now be done in the additional env files (more details further below, for example for `kopano_server` this file is called `kopano_server.env`). If you only want to run a subset of containers it is recommended to create a copy of `docker-compose.yml` and specify your copy when running. e.g. like ´docker-compose -f my-setup.yml up -d´.
 
 ## Is this project also interesting for me when I already have a (non-Docker) Kopano environment?
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This repository contains an easy to replicate recipe to spin up a [Kopano](https
 
 The `docker-compose.yml` file by default pulls Docker containers from https://hub.docker.com/r/zokradonh/kopano_core/ and https://hub.docker.com/r/zokradonh/kopano_webapp/. These images are based on the [Kopano nightly builds](https://download.kopano.io/community/) and will contain the latest version available from the time the image was built.
 
+## Updating
+
+Previously the `docker-compose.yml` file was not part of the git repository, which made it harder for users to pick and apply changes in the upstreamed `docker-compose.yml-example` file. This has meanwhile been changed and a `git pull` will now pull changes directly into `docker-compose.yml`. If you need to configure additional env variables, this can now be done in the additional env files (more details further below, for example for `kopano_server` this file is called `kopano_server.env`). If you only want to run a subset of containers it is recommended to create a copy of `docker-compose.yml` and specify your copy when running. e.g. like ´docker-compose -f my-setup.yml up -d´.
+
 ## Is this project also interesting for me when I already have a (non-Docker) Kopano environment?
 
 Yes, indeed. You could for example use this to easily try out newer Kopano WebApp or Z-Push releases, without touching your production environment. Through the `zokradonh/kopano_core` image you could even try out newer version of e.g. `kopano-gateway` without jumping into a dependecy mess in your production environment.
@@ -30,7 +34,9 @@ And last but not least this project also offers a `zokradonh/kopano_utils` image
 
 ### Need to adjust any values after the initial run of `setup.sh`?
 
-If you want to modify some of the values from the `setup.sh` run you can simply edit `.env` in your favourite editor. Repeated runs of `setup.sh` will neither modify `docker-compose.yml` nor `.env`. In that file you will also find some given defaults like ldap query filters and the local ports for the reverse proxy.
+If you want to modify some of the values from the `setup.sh` run you can simply edit `.env` in your favourite editor. Repeated runs of `setup.sh` will neither modify `docker-compose.yml` nor `.env`. In the ´.env´ file you will also find some given defaults like ldap query filters and the local ports for the reverse proxy.
+
+Additionally a dedicated env file is created for each container (at least where that would make sense). The env file has the container name as part of the file name. For example for the `kopano_server` container the filename is `kopano_server.env`. These additional env files are auto created when running `setup.sh`
 
 ### How to use a newer version than the one available from the Docker Hub?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - LDAP_ADMIN_PASSWORD=${LDAP_ADMIN_PASSWORD}
       - LDAP_READONLY_USER=true
       - LDAP_READONLY_USER_PASSWORD=${LDAP_READONLY_USER_PASSWORD}
+    env_file:
+      - ldap.env
     command: "--loglevel info --copy-service"
     volumes:
       - ldap:/var/lib/ldap
@@ -89,6 +91,8 @@ services:
       - PASSWORD_MIN_DIGIT=${SELF_SERVICE_PASSWORD_MIN_DIGIT}
       - PASSWORD_MIN_SPECIAL=${SELF_SERVICE_PASSWORD_MIN_SPECIAL}
       - PASSWORD_HASH=CRYPT
+    env_file:
+      - password-self-service.env
     expose:
       - "80"
     networks:
@@ -141,6 +145,8 @@ services:
       - ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1
       - POSTFIX_DAGENT=lmtp:kopano_dagent:2003
       - REPORT_RECIPIENT=1
+    env_file:
+      - mail.env
     networks:
       - kopano-net
       - ldap-net
@@ -162,6 +168,8 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE}
+    env_file:
+      - db.env
     healthcheck:
       test: ["CMD-SHELL", 'mysql --database=$$MYSQL_DATABASE --password=$$MYSQL_ROOT_PASSWORD --execute="SELECT count(table_name) > 0 FROM information_schema.tables;" --skip-column-names -B']
       interval: 30s
@@ -173,6 +181,8 @@ services:
   kopano_ssl:
     image: ${docker_repo:?err}/kopano_ssl
     container_name: kopano_ssl
+    env_file:
+      - kopano_ssl.env
     volumes:
       - kopanossl/:/kopano/ssl
 
@@ -215,6 +225,8 @@ services:
       - KCCONF_SERVER_KCOIDC_ISSUER_IDENTIFIER=https://${FQDN}
       - KCCONF_SERVER_KCOIDC_INSECURE_SKIP_VERIFY=${INSECURE}
       - KCCONF_SERVER_KCOIDC_INITIALIZE_TIMEOUT=360
+    env_file:
+      - kopano_server.env
     networks:
       - kopano-net
       - ldap-net
@@ -234,6 +246,8 @@ services:
     environment:
       - TZ=${TZ}
       - ADDITIONAL_KOPANO_WEBAPP_PLUGINS=${ADDITIONAL_KOPANO_WEBAPP_PLUGINS}
+    env_file:
+      - kopano_webapp.env
     networks:
       - web-net
       - kopano-net
@@ -248,6 +262,8 @@ services:
       - zpushstates/:/var/lib/z-push/
     environment:
       - TZ=${TZ}
+    env_file:
+      - kopano_zpush.env
     networks:
       - web-net
       - kopano-net
@@ -260,6 +276,8 @@ services:
     environment:
       - SERVICE_TO_START=grapi
       - TZ=${TZ}
+    env_file:
+      - kopano_grapi.env
     networks:
       - kopano-net
 
@@ -278,6 +296,8 @@ services:
       - KCCONF_KAPID_LOG_LEVEL=DEBUG
       - KCCONF_KAPID_OIDC_ISSUER_IDENTIFIER=https://${FQDN}
       - KCCONF_KAPID_INSECURE=${INSECURE}
+    env_file:
+      - kopano_kapi.env
     networks:
       - kopano-net
       - web-net
@@ -293,6 +313,8 @@ services:
       - TZ=${TZ}
       - KCCONF_DAGENT_LOG_LEVEL=3
       - KCCONF_DAGENT_SSLKEY_FILE=/kopano/ssl/kdagent.pem
+    env_file:
+      - kopano_dagent.env
     networks:
       - kopano-net
 
@@ -310,6 +332,8 @@ services:
       - KCCONF_SPOOLER_LOG_LEVEL=3
       - KCCONF_SPOOLER_SMTP_SERVER=mail
       - KCCONF_SPOOLER_SSLKEY_FILE=/kopano/ssl/kspooler.pem
+    env_file:
+      - kopano_spooler.env
     networks:
       - kopano-net
 
@@ -323,7 +347,9 @@ services:
       - SERVICE_TO_START=gateway
       - TZ=${TZ}
       - KCCONF_GATEWAY_SERVER_SOCKET=http://kopano_server:236/
-      - KCCONF_GATEWAY_LOG_LEVEL=6
+      - KCCONF_GATEWAY_LOG_LEVEL=3
+    env_file:
+      - kopano_gateway.env
     networks:
       - kopano-net
 
@@ -337,6 +363,8 @@ services:
       - SERVICE_TO_START=ical
       - TZ=${TZ}
       - KCCONF_ICAL_SERVER_SOCKET=http://kopano_server:236/
+    env_file:
+      - kopano_ical.env
     networks:
       - kopano-net
 
@@ -349,6 +377,8 @@ services:
     environment:
       - SERVICE_TO_START=monitor
       - TZ=${TZ}
+    env_file:
+      - kopano_monitor.env
     networks:
       - kopano-net
 
@@ -362,6 +392,8 @@ services:
     environment:
       - SERVICE_TO_START=search
       - TZ=${TZ}
+    env_file:
+      - kopano_search.env
     networks:
       - kopano-net
 
@@ -374,6 +406,8 @@ services:
      - kopanosocket/:/run/kopano
     environment:
      - FQDN=${FQDN}
+    env_file:
+     - kopano_konnect.env
     networks:
      - kopano-net
      - web-net
@@ -392,6 +426,8 @@ services:
     environment:
      - INSECURE=${INSECURE}
      - oidc_issuer_identifier=https://${FQDN}
+    env_file:
+     - kopano_kwmserver.env
     volumes:
      - kopanossl/:/kopano/ssl
     networks:
@@ -403,6 +439,8 @@ services:
     environment:
      - SERVICE_TO_START=meet
      - KCCONF_KWEBD_TLS=no
+    env_file:
+     - kopano_meet.env
     depends_on:
      - kopano_kapi
      - kopano_konnect

--- a/setup.sh
+++ b/setup.sh
@@ -10,11 +10,6 @@ random_string() {
 	hexdump -n 16 -v -e '/1 "%02X"' /dev/urandom
 }
 
-if [ ! -e ./docker-compose.yml ]; then
-	echo "copying example compose file"
-	cp docker-compose.yml-example docker-compose.yml
-fi
-
 LANG_OPTIONS=("de-at" "de-ch" "de-de" "en" "en-gb" "es" "fr" "it" "nl" "pl-pl")
 PLUGIN_OPTIONS=("contactfax" "desktopnotifications" "filepreviewer" "files" "filesbackend-smb" "filesbackend-owncloud" "folderwidgets" "gmaps" "intranet" "mattermost" "mdm" "pimfolder" "quickitems" "smime" "titlecounter" "webappmanual" "zdeveloper")
 
@@ -68,6 +63,11 @@ docker_tag_search () {
 
 	echo "$results" | xargs -n1 | sort -ru | xargs
 }
+
+echo "Creating individual env files for containers (if they do not exist already)"
+for dockerenv in ldap password-self-service mail db kopano_ssl kopano_server kopano_webapp kopano_zpush kopano_grapi kopano_kapi kopano_dagent kopano_spooler kopano_gateway kopano_ical kopano_monitor kopano_search kopano_konnect kopano_kwmserver kopano_meet; do
+	touch ./"$dockerenv".env
+done
 
 if [ ! -e ./.env ]; then
 	PRINT_SETUP_SUCCESS=""


### PR DESCRIPTION
Since the docker-compose.yml is still changing a lot this can lead to some confusion to some users. By adding docker-compose.yml to the versioning these confusions are probably dealt with best.

~~ps: still needs to be rebased to get rid of other commits~~