### PR TITLE
Enables caldav via reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -363,10 +363,12 @@ services:
       - SERVICE_TO_START=ical
       - TZ=${TZ}
       - KCCONF_ICAL_SERVER_SOCKET=http://kopano_server:236/
+      - KCCONF_ICAL_ICAL_LISTEN=*:80
     env_file:
       - kopano_ical.env
     networks:
       - kopano-net
+			- web-net
 
   kopano_monitor:
     image: ${docker_repo:?err}/kopano_core:${CORE_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -368,7 +368,7 @@ services:
       - kopano_ical.env
     networks:
       - kopano-net
-			- web-net
+      - web-net
 
   kopano_monitor:
     image: ${docker_repo:?err}/kopano_core:${CORE_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -363,7 +363,6 @@ services:
       - SERVICE_TO_START=ical
       - TZ=${TZ}
       - KCCONF_ICAL_SERVER_SOCKET=http://kopano_server:236/
-      - KCCONF_ICAL_ICAL_LISTEN=*:80
     env_file:
       - kopano_ical.env
     networks:

--- a/web/kweb.cfg
+++ b/web/kweb.cfg
@@ -152,6 +152,14 @@
         try_duration 30s
     }
 
+    proxy /caldav/ kopano_ical:80 {
+        fail_timeout 10s
+        try_duration 30s
+        transparent
+        keepalive 100
+    }
+    folderish /caldav
+
     proxy /ldap-admin/ ldap-admin:80 {
         without /ldap-admin
         transparent

--- a/web/kweb.cfg
+++ b/web/kweb.cfg
@@ -152,11 +152,10 @@
         try_duration 30s
     }
 
-    proxy /caldav/ kopano_ical:80 {
+    proxy /caldav/ kopano_ical:8080 {
         fail_timeout 10s
         try_duration 30s
         transparent
-        keepalive 100
     }
     folderish /caldav
 


### PR DESCRIPTION
Enables caldav via reverse proxy on /caldav/ - see https://github.com/zokradonh/kopano-docker/issues/95
