### PR TITLE
allow local overrides to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 data/*
 .env
 *.env
+docker-compose.override.yml


### PR DESCRIPTION
Exclude docker-compose.override.yml file from git updates to allow for local customizations of projects docker-compose.yml file