### PR TITLE
Remove redundant explicit name for ldap-net.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -504,5 +504,4 @@ networks:
   kopano-net:
     driver: bridge
   ldap-net:
-    name: ldap-net
     driver: bridge


### PR DESCRIPTION
Since the custom name for the network ldap-net is identical to the default, this line is redundant.