### PR TITLE
add small modification for use on demo.kopano.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,12 @@ build-web:
 build-webapp: build-php
 	component=webapp make build
 
+# replaces the actual kopano_webapp container with one that has login hints for demo.kopano.com
+build-webapp-demo:
+	docker build \
+		-f webapp/Dockerfile.demo \
+		-t $(docker_repo)/kopano_webapp webapp/
+
 build-zpush:
 	component=zpush make build
 

--- a/webapp/Dockerfile.demo
+++ b/webapp/Dockerfile.demo
@@ -1,0 +1,5 @@
+ARG docker_repo=zokradonh
+FROM ${docker_repo}/kopano_webapp
+
+RUN sed -i '1s/^/<?php  $user="user".rand(1, 15); ?>\n/' /usr/share/kopano-webapp/server/includes/templates/login.php && \
+    sed -i 's/id="password"/id="password" value="<?php echo $user; ?>"/' /usr/share/kopano-webapp/server/includes/templates/login.php


### PR DESCRIPTION
on demo systems one can now run `make build-webapp-demo` and then get a kopano_webapp container with added login hints

Signed-off-by: Felix Bartels <felix@host-consultants.de>