### PR TITLE
fixup check for jq in version.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -508,7 +508,7 @@ services:
       - kopano_zpush
     environment:
       - TZ=${TZ}
-      - CRON_KOPANOUSERS=10 * * * * docker exec kopano_server kopano-cli --sync
+      - CRON_KOPANOUSERS=10 * * * * docker exec kopano_server kopano-admin --sync
       - CRON_ZPUSHGAB=0 22 * * * docker exec kopano_zpush z-push-gabsync -a sync
       - CRONDELAYED_KBACKUP=30 1 * * * docker run --rm -it zokradonh/kopano_utils kopano-backup -h
     env_file:

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if ! hash jq; then
+if ! command -v jq > /dev/null; then
 	echo "Please install jq in order to run this build script."
 	exit 1
 fi


### PR DESCRIPTION
replace kopano-cli in scheduler container (for the moment, binary is currently missing in master)

Signed-off-by: Felix Bartels <felix@host-consultants.de>