### PR TITLE
make sure to pull in updates for the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ ifdef TRAVIS
 	docker pull  $(docker_repo)/kopano_$(component):builder || true
 endif
 	docker build \
+		--pull \
 		--build-arg docker_repo=${docker_repo} \
 		--build-arg KOPANO_CORE_VERSION=${core_download_version} \
 		--build-arg KOPANO_$(COMPONENT)_VERSION=${$(component)_download_version} \


### PR DESCRIPTION
otherwise one could use (for example) an outdated debian base image when doing local builds