### PR TITLE
basis for discussion: make portmapping switchable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KOPANO_ZPUSH_REPOSITORY_URL := http://repo.z-hub.io/z-push:/final/Debian_9.0/
 RELEASE_KEY_DOWNLOAD := 0
 DOWNLOAD_COMMUNITY_PACKAGES := 1
 
-COMPOSE_FILE := docker-compose.yml
+DOCKERCOMPOSE_FILE := docker-compose.yml
 TAG_FILE := build.tags
 -include .env
 export
@@ -334,27 +334,27 @@ check-scripts:
 
 .PHONY: clean
 clean:
-	docker-compose -f $(COMPOSE_FILE) down -v --remove-orphans || true
+	docker-compose -f $(DOCKERCOMPOSE_FILE) down -v --remove-orphans || true
 
 .PHONY: test
 test: ## Build and start new containers for testing (also deletes existing data volumes).
-	docker-compose -f $(COMPOSE_FILE) down -v --remove-orphans || true
+	docker-compose -f $(DOCKERCOMPOSE_FILE) down -v --remove-orphans || true
 	make build-all
-	docker-compose -f $(COMPOSE_FILE) build
-	docker-compose -f $(COMPOSE_FILE) up -d
-	docker-compose -f $(COMPOSE_FILE) ps
+	docker-compose -f $(DOCKERCOMPOSE_FILE) build
+	docker-compose -f $(DOCKERCOMPOSE_FILE) up -d
+	docker-compose -f $(DOCKERCOMPOSE_FILE) ps
 
 test-update-env: ## Recreate containers based on updated .env.
-	docker-compose -f $(COMPOSE_FILE) up -d
+	docker-compose -f $(DOCKERCOMPOSE_FILE) up -d
 
 test-ci: ## Test if all containers start up
-	docker-compose -f $(COMPOSE_FILE) -f tests/test-container.yml build
-	docker-compose -f $(COMPOSE_FILE) -f tests/test-container.yml up -d
-	docker-compose -f $(COMPOSE_FILE) -f tests/test-container.yml ps
+	docker-compose -f $(DOCKERCOMPOSE_FILE) -f tests/test-container.yml build
+	docker-compose -f $(DOCKERCOMPOSE_FILE) -f tests/test-container.yml up -d
+	docker-compose -f $(DOCKERCOMPOSE_FILE) -f tests/test-container.yml ps
 	# TODO this just echos the exit code of the kopano_test container. if this is not 0 we should do something with it.
 	docker wait kopano_test_1
 	docker logs --tail 10 kopano_test_1
-	docker-compose -f $(COMPOSE_FILE) -f tests/test-container.yml stop 2>/dev/null
+	docker-compose -f $(DOCKERCOMPOSE_FILE) -f tests/test-container.yml stop 2>/dev/null
 	docker rm kopano_test_1
 
 test-security: ## Scan containers with Trivy for known security risks (not part of CI workflow for now).
@@ -363,9 +363,9 @@ test-security: ## Scan containers with Trivy for known security risks (not part 
 	rm $(TAG_FILE)
 
 test-quick: ## Similar to test target, but does not delete existing data volumes and does not rebuild images.
-	docker-compose -f $(COMPOSE_FILE) stop || true
-	docker-compose -f $(COMPOSE_FILE) up -d
-	docker-compose -f $(COMPOSE_FILE) ps
+	docker-compose -f $(DOCKERCOMPOSE_FILE) stop || true
+	docker-compose -f $(DOCKERCOMPOSE_FILE) up -d
+	docker-compose -f $(DOCKERCOMPOSE_FILE) ps
 
 test-stop:
-	docker-compose -f $(COMPOSE_FILE) stop || true
+	docker-compose -f $(DOCKERCOMPOSE_FILE) stop || true

--- a/docker-compose.portmapping.yml
+++ b/docker-compose.portmapping.yml
@@ -1,0 +1,33 @@
+version: "3.5"
+
+services:
+  web:
+    ports:
+      - "${CADDY:-2015}:2015"
+      - "${HTTP:-80}:80"
+      - "${HTTPS:-443}:443"
+
+  ldap:
+    ports:
+      - ${LDAPPORT:-389}:389
+
+  mail:
+    ports:
+      - "${SMTPPORT:-25}:25"
+      - "${SMTPSPORT:-465}:465"
+      - "${MSAPORT:-587}:587"
+
+  kopano_server:
+    ports:
+      - ${KOPANOPORT:-236}:236
+      - ${KOPANOSPORT:-237}:237
+
+  kopano_gateway:
+    ports:
+      - "${POP3PORT:-110}:110"
+      - "${IMAPPORT:-143}:143"
+
+  kopano_ical:
+    ports:
+      - "${ICALPORT:-8080}:8080"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ services:
   web:
     image: ${docker_repo:-zokradonh}/kopano_web:${KWEB_VERSION:-latest}
     restart: unless-stopped
-    ports:
-      - "${CADDY:-2015}:2015"
-      - "${HTTP:-80}:80"
-      - "${HTTPS:-443}:443"
     environment:
       - EMAIL=${EMAIL:-off}
       - FQDN=${FQDN?err}
@@ -30,8 +26,6 @@ services:
     image: ${docker_repo:-zokradonh}/${LDAP_CONTAINER:-kopano_ldap_demo}:${LDAP_VERSION:-latest}
     restart: unless-stopped
     container_name: ${COMPOSE_PROJECT_NAME}_ldap
-    ports:
-      - ${LDAPPORT:-389}:389
     environment:
       - LDAP_ORGANISATION=${LDAP_ORGANISATION}
       - LDAP_DOMAIN=${LDAP_DOMAIN}
@@ -105,10 +99,6 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME}_mail
     depends_on:
       - ldap
-    ports:
-      - "${SMTPPORT:-25}:25"
-      - "${SMTPSPORT:-465}:465"
-      - "${MSAPORT:-587}:587"
     volumes:
       - maildata:/var/mail
       - mailstate:/var/mail-state
@@ -196,9 +186,6 @@ services:
       - ldap
       - kopano_ssl
       - kopano_konnect
-    ports:
-      - ${KOPANOPORT:-236}:236
-      - ${KOPANOSPORT:-237}:237
     environment:
       - SERVICE_TO_START=server
       - TZ=${TZ}
@@ -367,9 +354,6 @@ services:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
     depends_on:
       - kopano_server
-    ports:
-      - "${POP3PORT:-110}:110"
-      - "${IMAPPORT:-143}:143"
     volumes:
       - kopanossl/:/kopano/ssl
       - kopanosocket/:/run/kopano
@@ -387,8 +371,6 @@ services:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
     depends_on:
       - kopano_server
-    ports:
-      - "${ICALPORT:-8080}:8080"
     volumes:
       - kopanossl/:/kopano/ssl
       - kopanosocket/:/run/kopano

--- a/examples/traefik-proxy-subdomain.md
+++ b/examples/traefik-proxy-subdomain.md
@@ -1,0 +1,73 @@
+Situation and motivation:
+---
+* running the kopano stack behind an ssl-terminating proxy
+* as less as possible mantainence affort --> run the kopano stack as close as possible at the default configuration
+* using the kopano-stack to provide a central ldap authentication for the domain, but running the frontents using a subdomain
+
+Way to go:
+--
+1. initial clean **setup of kopano stack** --> follow the documentation of https://github.com/zokradonh/kopano-docker/blob/master/README.md
+    1. clone the repo https://github.com/zokradonh/kopano-docker
+    2. run the setup.sh (only steps, necessary for the configuration is shown here)
+       1. Name of the Organisation for LDAP `mydomain.com`
+       2. FQDN to be used (for reverse proxy) `kopano.mydomain.com`
+       3. Email address to use for Lets Encrypt. `self_signed`
+       4. Name of the BASE DN for LDAP `dc=mydomain,dc=com`
+       5. E-Mail Address displayed for the 'postmaster' `postmaster@mydomain.com`
+
+2. ensure ldap and reverse-proxy domain is splitted correctly in generated `.env` file:
+```
+LDAP_DOMAIN=mydomain.com
+LDAP_BASE_DN=dc=mydomain,dc=com
+
+FQDN=kopano.mydomain.com
+```
+
+3. ensure kwmserver is able to connect through an enpoint with valid ssl-certificate
+```
+FQDNCLEANED=somethingInvalidToEnforceConnectionFromOutsideEndpoint
+```
+
+4. ensure your traefik instance outside of the kopano-stack does allow **proxying to self-signed certificates**:
+```
+command: --insecureSkipVerify=true
+```
+
+5. disable the docker-host portmapping of the kopano-caddy proxy in `docker-compose.yml` to not interference with your traefik proxy
+```
+services:
+  web:
+...
+#    ports:
+#      - "${CADDY:-2015}:2015"
+#      - "${HTTP:-80}:80"
+#      - "${HTTPS:-443}:443"
+```
+
+6. make the self-signed kopano reverse-proxy available in traeffik via `docker-compose.override.yml`
+```
+version: "3.5"
+
+services:
+  web:
+    networks:
+      proxy-net:
+    labels:
+      traefik.enable: true 
+      traefik.frontend.rule: "Host:${FQDN}"
+      traefik.port: 2015
+      traefik.protocol: https
+      traefik.docker.network: "proxy-net"
+      traefik.frontend.headers.forceSTSHeader: true
+      traefik.frontend.headers.STSSeconds: 315360000
+      traefik.frontend.headers.STSIncludeSubdomains: true
+      traefik.frontend.headers.STSPreload: true
+
+networks:
+  proxy-net:
+    external: true
+  ldap-net:
+    name: ldap-net
+```
+
+Everything else should be configurable as normal. My test-setup showed a functional active-sync connection using the mdm plugin in the webapp, as well as screensharing via kopano-meet. 

--- a/setup.sh
+++ b/setup.sh
@@ -243,9 +243,15 @@ if [ ! -e ./.env ]; then
 
 	echo "${PRINT_SETUP_SUCCESS}"
 
+if [ ! -e ./docker-compose.override.yml ]; then
+	echo 'version: "3.5"' >> ./docker-compose.override.yml
+fi
+
 	cat <<EOF > "./.env"
 # please consult https://github.com/zokradonh/kopano-docker
 # for possible configuration values and their impact
+COMPOSE_FILE=docker-compose.yml:docker-compose.portmapping.yml:docker-compose.override.yml
+
 CORE_VERSION=$CORE_VERSION
 WEBAPP_VERSION=$WEBAPP_VERSION
 ZPUSH_VERSION=$ZPUSH_VERSION


### PR DESCRIPTION
**move portmapping into docker-compose.portmapping.yml and load it automatically**

This changeset enables the possiblity to switch off all host port mappings without patching the docker-compose.yml. Only the COMPOSE_FILE list has to be patched in the .env.

**content of this PR:**
This PR does not change the behavior of this kopano stack. Only the portmapping part is splitted up.

Ensure loading of docker-compose.portmapping.yml via COMPOSE_FILE in .env. This disables the override automatism and starts only when the override.yml exists. This problem is bypassed by enforcing the creation an empty override.yml during setup.sh.