### PR TITLE
Use jq's -r switch instead of sed

### DIFF
--- a/base/create-kopano-repo.sh
+++ b/base/create-kopano-repo.sh
@@ -14,8 +14,8 @@ function h5ai_query {
     distribution=${2:-Debian_9.0}
 
     filename=$(curl -s -S -L -d "action=get&items%5Bhref%5D=%2Fcommunity%2F$component%3A%2F&items%5Bwhat%5D=1" -H \
-                "Accept: application/json" https://download.kopano.io/community/ | jq '.items[].href' | \
-                grep "$distribution-all\|$distribution-amd64" | sed 's#"##g' | sed "s#/community/$component:/##")
+                "Accept: application/json" https://download.kopano.io/community/ | jq -r '.items[].href' | \
+                grep "$distribution-all\|$distribution-amd64" | sed "s#/community/$component:/##")
 
     if [ -z "${filename// }" ]; then
         echo "unknown component"


### PR DESCRIPTION
Use jq's -r switch instead of sed to remove double-quotes.