### PR TITLE
wip: add some more documentation about used ports

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -41,3 +41,9 @@ Example:
 Depending on the overall performance of the system and the amount of user the first execution of this command will take a moment before it produces any output. This is since this command kicks off the mailbox creation for the users.
 
 See https://documentation.kopano.io/kopanocore_administrator_manual/configure_kc_components.html#testing-ldap-configuration for more information.
+
+## Ports & Proxying
+
+- kopano-server is configured to listen on the ports 236 (plain) and 237 (https)
+- kopano-ical is configured to listen on the port 8080, but the web container is also configured to proxy access to http(s)://FQDN/caldav to kopano-ical
+- kopano-gateway is configured to listen on IMAP traffic on port 143. Pop3 is deactivated by default but whould be listening on port 110. Pop3s and IMAPs are currently not configured. (see https://github.com/zokradonh/kopano-docker/issues/16 for more details).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -368,6 +368,7 @@ services:
     depends_on:
       - kopano_server
     ports:
+      - "${POP3PORT:-110}:110"
       - "${IMAPPORT:-143}:143"
     volumes:
       - kopanossl/:/kopano/ssl
@@ -386,6 +387,8 @@ services:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
     depends_on:
       - kopano_server
+    ports:
+      - "${ICALPORT:-8080}:8080"
     volumes:
       - kopanossl/:/kopano/ssl
       - kopanosocket/:/run/kopano


### PR DESCRIPTION
also add more ports to docker-compose.yml

Found this old commit that I did not yet open a pr with. Taking https://github.com/zokradonh/kopano-docker/pull/171 into account its probably better to have a dedicated compose file per service (that only specifies the exposed ports of this service). 

Also the documentation for ports should move from the core readme to the service in question.