### PR TITLE
don't restart scheduler when it fails to start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -500,7 +500,6 @@ services:
   kopano_scheduler:
     image: ${docker_repo:-zokradonh}/kopano_scheduler:${SCHEDULER_VERSION:-latest}
     container_name: ${COMPOSE_PROJECT_NAME}_scheduler
-    restart: unless-stopped
     networks:
       - kopano-net
       - ldap-net


### PR DESCRIPTION
it could cause a restart loop when one of the cron commands fail to execute. rather let the container stop instead.