### PR TITLE
container restart unless stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
 
   ldap-admin:
     image: osixia/phpldapadmin:0.7.2
+    restart: unless-stopped
     depends_on:
       - ldap
     environment:
@@ -55,6 +56,7 @@ services:
 
   password-self-service:
     image: tiredofit/self-service-password:3.0
+    restart: unless-stopped
     domainname: ${LDAP_DOMAIN}
     depends_on:
       - ldap
@@ -179,6 +181,7 @@ services:
 
   kopano_server:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     hostname: kopano_server
     container_name: ${COMPOSE_PROJECT_NAME}_server
     depends_on:
@@ -224,6 +227,7 @@ services:
 
   kopano_webapp:
     image: ${docker_repo:-zokradonh}/kopano_webapp:${WEBAPP_VERSION:-latest}
+    restart: unless-stopped
     hostname: kopano_webapp
     depends_on:
       - kopano_server
@@ -242,6 +246,7 @@ services:
 
   kopano_zpush:
     image: ${docker_repo:-zokradonh}/kopano_zpush:${ZPUSH_VERSION:-latest}
+    restart: unless-stopped
     hostname: kopano_zpush
     container_name: ${COMPOSE_PROJECT_NAME}_zpush
     depends_on:
@@ -260,6 +265,7 @@ services:
 
   kopano_grapi:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     container_name: ${COMPOSE_PROJECT_NAME}_grapi
     depends_on:
       - kopano_server
@@ -275,6 +281,7 @@ services:
 
   kopano_kapi:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     container_name: ${COMPOSE_PROJECT_NAME}_kapi
     depends_on:
       - kopano_grapi
@@ -296,6 +303,7 @@ services:
 
   kopano_kdav:
     image: ${docker_repo:-zokradonh}/kopano_kdav:${KDAV_VERSION:-latest}
+    restart: unless-stopped
     hostname: kopano_kdav
     container_name: ${COMPOSE_PROJECT_NAME}_kdav
     depends_on:
@@ -312,6 +320,7 @@ services:
 
   kopano_dagent:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     depends_on:
       - kopano_server
     volumes:
@@ -329,6 +338,7 @@ services:
 
   kopano_spooler:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     hostname: spooler
     domainname: ${LDAP_DOMAIN}
     depends_on:
@@ -350,6 +360,7 @@ services:
 
   kopano_gateway:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     depends_on:
       - kopano_server
     volumes:
@@ -367,6 +378,7 @@ services:
 
   kopano_ical:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     depends_on:
       - kopano_server
     volumes:
@@ -384,6 +396,7 @@ services:
 
   kopano_monitor:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     depends_on:
       - kopano_server
     volumes:
@@ -399,6 +412,7 @@ services:
 
   kopano_search:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    restart: unless-stopped
     container_name: ${COMPOSE_PROJECT_NAME}_search
     depends_on:
       - kopano_server
@@ -416,6 +430,7 @@ services:
 
   kopano_konnect:
     image: ${docker_repo:-zokradonh}/kopano_konnect:${KONNECT_VERSION:-latest}
+    restart: unless-stopped
     command: wrapper.sh
     depends_on:
       - kopano_ssl
@@ -436,6 +451,7 @@ services:
 
   kopano_playground:
     image: ${docker_repo:-zokradonh}/kopano_playground
+    restart: unless-stopped
     depends_on:
       - kopano_kapi
       - kopano_konnect
@@ -445,6 +461,7 @@ services:
 
   kopano_kwmserver:
     image: ${docker_repo:-zokradonh}/kopano_kwmserver:${KWM_VERSION:-latest}
+    restart: unless-stopped
     command: wrapper.sh
     depends_on:
       - kopano_kapi
@@ -463,6 +480,7 @@ services:
 
   kopano_meet:
     image: ${docker_repo:-zokradonh}/kopano_meet:${MEET_VERSION:-latest}
+    restart: unless-stopped
     environment:
       - SERVICE_TO_START=meet
       - KCCONF_MEET_guests_enabled=true
@@ -479,6 +497,7 @@ services:
 
   kopano_scheduler:
     image: ${docker_repo:-zokradonh}/kopano_scheduler:${SCHEDULER_VERSION:-latest}
+    restart: unless-stopped
     container_name: ${COMPOSE_PROJECT_NAME}_scheduler
     networks:
       - kopano-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -497,7 +497,7 @@ services:
 
   kopano_scheduler:
     image: ${docker_repo:-zokradonh}/kopano_scheduler:${SCHEDULER_VERSION:-latest}
-    restart: no
+    restart: "no"
     container_name: ${COMPOSE_PROJECT_NAME}_scheduler
     networks:
       - kopano-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -497,7 +497,7 @@ services:
 
   kopano_scheduler:
     image: ${docker_repo:-zokradonh}/kopano_scheduler:${SCHEDULER_VERSION:-latest}
-    restart: unless-stopped
+    restart: no
     container_name: ${COMPOSE_PROJECT_NAME}_scheduler
     networks:
       - kopano-net


### PR DESCRIPTION
When i restart my docker host a lot of kopano services do not restart. So i added a lot of restart statements in my override.yml. This works pretty fine, but i think the restart-unless-stopped mechanism could be the default one for this stack. So here is my PR :)

As far as i understand, this hits every service, except the ssl one, because this is only fired up once for initialization. So i omitted the restart statement there.