### PR TITLE
Use login via oidc in Kopano WebApp by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,9 @@ services:
     environment:
       - TZ=${TZ}
       - ADDITIONAL_KOPANO_WEBAPP_PLUGINS=${ADDITIONAL_KOPANO_WEBAPP_PLUGINS}
+      - KCCONF_WEBAPP_OIDC_ISS=https://${FQDN}
+      - KCCONF_WEBAPP_OIDC_CLIENT_ID=webapp
+
     env_file:
       - kopano_webapp.env
     networks:


### PR DESCRIPTION
fixes #202

Signed-off-by: Felix Bartels <felix@host-consultants.de>