### PR TITLE
the mime type error was thrown since the meet container did not have …

### DIFF
--- a/meet/Dockerfile
+++ b/meet/Dockerfile
@@ -43,7 +43,9 @@ RUN \
     # install
     apt-get update && \
     set -x && \
+    # TODO mime-support could be remove once its an official dependency of kopano-kwebd
     apt-get install --no-install-recommends -y \
+	mime-support \
         kopano-kwebd \
 	kopano-meet kopano-meet-webapp \
         ${ADDITIONAL_KOPANO_PACKAGES} \

--- a/web/kweb.cfg
+++ b/web/kweb.cfg
@@ -9,9 +9,6 @@
     gzip
     header / Server kweb
 
-    # TODO this should actually not be neccesary since the container has the mailcap package installed
-    mime .json application/json
-
     tls {%EMAIL%}
 
     limits {


### PR DESCRIPTION
…the mime-support package

Signed-off-by: Felix Bartels <felix@host-consultants.de>

Fixes https://github.com/zokradonh/kopano-docker/issues/197