### PR TITLE
Check if `PERMIT_DOCKER=network` work after recent changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,7 @@ test-goss: ## Test configuration of containers with goss
 test-commander: ## Test scripts with commander
 	commander test tests/commander.yaml
 	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=core/commander/server dccommander run kopano_server
+	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=core/commander/spooler dccommander run kopano_spooler
 
 test-security: ## Scan containers with Trivy for known security risks (not part of CI workflow for now).
 	cat $(TAG_FILE) | xargs -I % sh -c 'trivy --exit-code 0 --severity HIGH --quiet --auto-refresh %'

--- a/core/commander/spooler/commander.yaml
+++ b/core/commander/spooler/commander.yaml
@@ -1,0 +1,9 @@
+tests:
+  test sending mail:
+    command:  apt update && apt install -y swaks netbase && dockerize -wait tcp://"$KCCONF_SPOOLER_SMTP_SERVER":25 -timeout 1080s swaks --to user1@kopano.demo --server $KCCONF_SPOOLER_SMTP_SERVER
+    exit-code: 0
+
+config:
+  env:
+    PATH: ${PATH}
+    KCCONF_SPOOLER_SMTP_SERVER: ${KCCONF_SPOOLER_SMTP_SERVER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - SASLAUTHD_MECHANISMS=ldap
       - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS}
       - SMTP_ONLY=1
-      - PERMIT_DOCKER=host
+      - PERMIT_DOCKER=network
       - ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1
       - POSTFIX_DAGENT=lmtp:kopano_dagent:2003
       - REPORT_RECIPIENT=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - SASLAUTHD_MECHANISMS=ldap
       - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS}
       - SMTP_ONLY=1
-      - PERMIT_DOCKER=network
+      - PERMIT_DOCKER=connected-networks
       - ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1
       - POSTFIX_DAGENT=lmtp:kopano_dagent:2003
       - REPORT_RECIPIENT=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ldap-net
 
   mail:
-    image: tvial/docker-mailserver:release-v6.1.0
+    image: tvial/docker-mailserver:testing
     restart: unless-stopped
     hostname: mail
     domainname: ${LDAP_DOMAIN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ldap-net
 
   mail:
-    image: tvial/docker-mailserver:testing
+    image: tvial/docker-mailserver:release-v6.2.0
     restart: unless-stopped
     hostname: mail
     domainname: ${LDAP_DOMAIN}


### PR DESCRIPTION
This PR is just here for verification. should not be merged before there is a new upstream release.

TODO:
- [x] switch back to official release for docker-mailserver once there is one