### PR TITLE
Added automatic Z-Push shared folder registration.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,9 @@ services:
       - zpushstates/:/var/lib/z-push/
     environment:
       - TZ=${TZ}
+      # Shared folders automatically assigned to all users in the format: [{"name":"<folder name>","id":"<kopano folder id>","type":"<type>","flags":"<flags>"},...]
+      # For more information on the parameters see the z-push-admin help for the addshared-action.
+      - ZPUSH_ADDITIONAL_FOLDERS=[]
     env_file:
       - kopano_zpush.env
     networks:

--- a/zpush/commander.yaml
+++ b/zpush/commander.yaml
@@ -35,6 +35,41 @@ tests:
     stdout:
       contains:
         - "define('USERNAME', 'SYSTEM');"
+  start-service script (no additional folders):
+    command: bash -c "shopt -s expand_aliases; alias exec='echo exec'; alias php-fpm7.0='echo php-fpm7.0'; . /kopano/start.sh" && cat /etc/z-push/z-push.conf.php
+    exit-code: 0
+    stdout:
+      contains:
+        - "  $additionalFolders = array(\n  );"
+      not-contains: # default entry
+        - "\t$additionalFolders = array("
+        - "\t);"
+  start-service script (empty additional folders):
+    command: bash -c "shopt -s expand_aliases; alias exec='echo exec'; alias php-fpm7.0='echo php-fpm7.0'; . /kopano/start.sh" && cat /etc/z-push/z-push.conf.php
+    exit-code: 0
+    stdout:
+      contains:
+        - "  $additionalFolders = array(\n  );"
+      not-contains: # default entry
+        - "\t$additionalFolders = array("
+        - "\t);"
+    config:
+      env:
+        ZPUSH_ADDITIONAL_FOLDERS: "[]"
+  start-service script (set additional folders):
+    command: bash -c "shopt -s expand_aliases; alias exec='echo exec'; alias php-fpm7.0='echo php-fpm7.0'; . /kopano/start.sh" && cat /etc/z-push/z-push.conf.php
+    exit-code: 0
+    stdout:
+      contains:
+        - "  $additionalFolders = array(\n    array('store' => \"SYSTEM\", 'folderrid' => \"42\", 'name' => \"Calendar\", 'type' => \"SYNC_FOLDER_TYPE_USER_APPOINTMENT\", 'flags' => \"4\"),\n    array('store' => \"SYSTEM\", 'folderrid' => \"21\", 'name' => \"Mail\", 'type' => \"SYNC_FOLDER_TYPE_USER_MAIL\", 'flags' => \"0\"),\n  );"
+      not-contains: # default entry
+        - "\t$additionalFolders = array("
+        - "\t);"
+    config:
+      env:
+        ZPUSH_ADDITIONAL_FOLDERS: "[{\"name\":\"Calendar\",\"id\":\"42\",\"type\":\"SYNC_FOLDER_TYPE_USER_APPOINTMENT\",\"flags\":\"4\"},{\"name\":\"Mail\",\"id\":\"21\",\"type\":\"SYNC_FOLDER_TYPE_USER_MAIL\",\"flags\":\"0\"}]"
+
+
 config:
   env:
     DEBUG: ${DEBUG}


### PR DESCRIPTION
Via a new environment variable containing the relevant information in a
JSON string, shared folders can be specifified which will be assigned
to all users during container startup.

Z-Push requires manual adding of shared users for each user - for
globally shared folders this is quite tedious. Defining this on service
stack level for automatic setup removes this burden (even though this
requires a container restart).

If the folders are already assigned, nothing happens. Folder removal
is not covered by this.