### PR TITLE
intruct curl to follow redirects

### DIFF
--- a/zpush/Dockerfile
+++ b/zpush/Dockerfile
@@ -44,7 +44,7 @@ RUN \
     # prepare z-push installation
     echo "deb ${KOPANO_ZPUSH_REPOSITORY_URL} /" > /etc/apt/sources.list.d/zpush.list && \
     # this is the same key as for the rest of the Kopano stack, making a separate download anyways as this may not be the case in the future 
-    curl -s -S -o - "${KOPANO_ZPUSH_REPOSITORY_URL}/Release.key" | apt-key add - && \
+    curl -s -S -L -o - "${KOPANO_ZPUSH_REPOSITORY_URL}/Release.key" | apt-key add - && \
     # install
     set -x && \
     # TODO set IGNORE_FIXSTATES_ON_UPGRADE https://jira.z-hub.io/browse/ZP-1164?jql=text%20~%20%22IGNORE_FIXSTATES_ON_UPGRADE%22


### PR DESCRIPTION
The z-push build was failing locally since the z-hub repo is now serves via https