### PR TITLE
Fixed issues with Z-Push shared folder configuration.

### DIFF
--- a/zpush/commander.yaml
+++ b/zpush/commander.yaml
@@ -61,7 +61,7 @@ tests:
     exit-code: 0
     stdout:
       contains:
-        - "  $additionalFolders = array(\n    array('store' => \"SYSTEM\", 'folderrid' => \"42\", 'name' => \"Calendar\", 'type' => \"SYNC_FOLDER_TYPE_USER_APPOINTMENT\", 'flags' => \"4\"),\n    array('store' => \"SYSTEM\", 'folderrid' => \"21\", 'name' => \"Mail\", 'type' => \"SYNC_FOLDER_TYPE_USER_MAIL\", 'flags' => \"0\"),\n  );"
+        - "  $additionalFolders = array(\n    array('store' => \"SYSTEM\", 'folderid' => \"42\", 'name' => \"Calendar\", 'type' => SYNC_FOLDER_TYPE_USER_APPOINTMENT, 'flags' => 4),\n    array('store' => \"SYSTEM\", 'folderid' => \"21\", 'name' => \"Mail\", 'type' => SYNC_FOLDER_TYPE_USER_MAIL, 'flags' => 0),\n  );"
       not-contains: # default entry
         - "\t$additionalFolders = array("
         - "\t);"

--- a/zpush/start.sh
+++ b/zpush/start.sh
@@ -106,7 +106,7 @@ perl -i -0pe 's/\$additionalFolders.*\);//s' /etc/z-push/z-push.conf.php
 echo -e "  \$additionalFolders = array(" >> /etc/z-push/z-push.conf.php
 echo "$ZPUSH_ADDITIONAL_FOLDERS" | jq -c '.[]' | while read -r folder; do
 	eval "$(echo "$folder" | jq -r '@sh "NAME=\(.name) ID=\(.id) TYPE=\(.type) FLAGS=\(.flags)"')"
-	echo -e "    array('store' => \"SYSTEM\", 'folderrid' => \"$ID\", 'name' => \"$NAME\", 'type' => \"$TYPE\", 'flags' => \"$FLAGS\")," >> /etc/z-push/z-push.conf.php
+	echo -e "    array('store' => \"SYSTEM\", 'folderid' => \"$ID\", 'name' => \"$NAME\", 'type' => $TYPE, 'flags' => $FLAGS)," >> /etc/z-push/z-push.conf.php
 done
 echo -e '  );' >> /etc/z-push/z-push.conf.php
 


### PR DESCRIPTION
setup.sh generated wrong config key for folder id and wrong datatypes
for folder type and flags. This has been corrected both there and in
the automated tests.

Automated tests did not catch it since they suffered the same issues; manual integration testing did not catch it since the respective folders in my setup were already registered manually, a fact that I missed. The error popped up after checking the log file, which complained about it.
