### PR TITLE
add tests for webapp plugins

### DIFF
--- a/tests/commander.yaml
+++ b/tests/commander.yaml
@@ -31,3 +31,24 @@ tests:
         - Debian
         - amd64
         - tar.gz
+  ./version.sh mdm:
+    exit-code: 0
+    stdout:
+      not-contains:
+        - Debian
+        - amd64
+        - tar.gz
+  ./version.sh files:
+    exit-code: 0
+    stdout:
+      not-contains:
+        - Debian
+        - amd64
+        - tar.gz
+  ./version.sh smime:
+    exit-code: 0
+    stdout:
+      not-contains:
+        - Debian
+        - amd64
+        - tar.gz


### PR DESCRIPTION
This test is expected to fail at the moment, since there is no Deb 9 download for Kopano files.