### PR TITLE
smaller konnect fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ test-commander: ## Test scripts with commander
 	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=core/commander/grapi dccommander run kopano_grapi
 	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=webapp dccommander run kopano_webapp
 	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=zpush dccommander run kopano_zpush
-	COMMANDER_OPTS="--concurrent 1 --verbose" COMMANDER_FILES_PATH=konnect dccommander run kopano_konnect
+	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=konnect dccommander run kopano_konnect
 	COMMANDER_OPTS="--concurrent 1" COMMANDER_FILES_PATH=scheduler dccommander run kopano_scheduler
 	# this test will fail if you are not on a whitelisted ip
 	commander test tests/commander-supported.yaml || true

--- a/konnect/README.md
+++ b/konnect/README.md
@@ -3,3 +3,5 @@
 [![](https://images.microbadger.com/badges/image/zokradonh/kopano_konnect.svg)](https://microbadger.com/images/zokradonh/kopano_konnect "Microbadger size/labels") [![](https://images.microbadger.com/badges/version/zokradonh/kopano_konnect.svg)](https://microbadger.com/images/zokradonh/kopano_konnect "Microbadger version")
 
 Image to run [Kopano Konnect](https://github.com/kopano-dev/konnect). Takes the [official image](https://cloud.docker.com/u/kopano/repository/docker/kopano/konnectd) and extends it for automatic configuration.
+
+Currently the container does not support dynamically adding additional clients to the konnectd identifier registration. To add additional values modify the file manually and mount it to `/etc/kopano/konnectd-identifier-registration.yaml` (the container uses this file as a template when adding the required values for Kopano Meet).

--- a/konnect/commander.yaml
+++ b/konnect/commander.yaml
@@ -30,6 +30,11 @@ tests:
     stdout:
       contains:
         - '"description": "Access Kopano Meet"'
+  identifier registration in /etc/kopano:
+    command: /commander/test-helper.sh && wrapper.sh && yq . $identifier_registration_conf
+    config:
+      env:
+        identifier_registration_conf: /etc/kopano/konnectd-identifier-registration.yaml
 config:
   env:
     PATH: ${PATH}


### PR DESCRIPTION
remove verbose in commander make target
add hint to the readme how to add own entries to registry
add test for the case that CONFIG_JSON and identifier_registration_conf are the same file