### PR TITLE
add entry for kopano kustomerd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,15 @@ services:
     volumes:
       - kopanossl/:/kopano/ssl
 
+  kopano_kustomer:
+    image: kopano/kustomerd:${KUSTOMER_VERSION:-latest}
+    restart: unless-stopped
+    command: serve --log-level debug
+    volumes:
+      - /etc/machine-id:/etc/machine-id
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id
+      - kopanosocket/:/run/kopano
+
   kopano_server:
     image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,8 @@ services:
     command: serve --log-level debug
     volumes:
       - /etc/machine-id:/etc/machine-id
-      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id\
+      - kopanolicenses:/etc/kopano/licenses
       - kopanosocket/:/run/kopano
 
   kopano_server:
@@ -519,6 +520,7 @@ volumes:
   kdavstates:
   kopanodata:
   kopanograpi:
+  kopanolicenses:
   kopanosocket:
   kopanossl:
   kopanowebapp:

--- a/examples/meet/docker-compose.yml
+++ b/examples/meet/docker-compose.yml
@@ -55,6 +55,16 @@ services:
     volumes:
       - kopanossl/:/kopano/ssl
 
+  kopano_kustomer:
+    image: kopano/kustomerd:${KUSTOMER_VERSION:-latest}
+    restart: unless-stopped
+    command: serve
+    volumes:
+      - /etc/machine-id:/etc/machine-id
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id\
+      - kopanolicenses:/etc/kopano/licenses
+      - kopanosocket/:/run/kopano
+
   kopano_grapi:
     image: ${docker_repo:-kopano}/kopano_core:${CORE_VERSION:-latest}
     restart: unless-stopped
@@ -178,6 +188,7 @@ services:
 
 volumes:
   kopanodata:
+  kopanolicenses:
   kopanosocket:
   kopanossl:
   ldap:


### PR DESCRIPTION
Kustomer is the service that will in the future monitor usage limits and support status for Kopano installations. At this point in time it does not do much yet.

source code is located at https://stash.kopano.io/projects/KGOL/repos/kustomer/browse (not yet public, but will be later).