### PR TITLE
drop cap_* for kweb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,6 @@ services:
       - EMAIL=${EMAIL:-off}
       - FQDN=${FQDNCLEANED?err}
     command: wrapper.sh
-    cap_drop:
-      - ALL
-    cap_add:
-      - CHOWN
-      - NET_BIND_SERVICE
-      - SETGID
-      - SETUID
     volumes:
       - /etc/machine-id:/etc/machine-id
       - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id


### PR DESCRIPTION
explicit capabilities are not longer required since the process is now running as nobody

fixes #322