### PR TITLE
Make build fail early if bad version string is received

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -72,4 +72,12 @@ filename=$(h5ai_query "$component" "$distribution" "$channel" "$branch")
 
 currentVersion=$(version_from_filename "$filename")
 
+versiontemp="${currentVersion//[^.]}"
+
+# a valid version number has at least two dots. e.g. 1.2.3
+if [ $versiontemp -lt 2 ]; then
+	echo "Malformed version recieved"
+	exit 1
+fi	
+
 echo "$currentVersion"

--- a/version.sh
+++ b/version.sh
@@ -75,7 +75,7 @@ currentVersion=$(version_from_filename "$filename")
 versiontemp="${currentVersion//[^.]}"
 # a valid version number has at least two dots. e.g. 1.2.3
 if [ ${#versiontemp} -lt 2 ]; then
-	echo "Malformed version recieved"
+	echo "Malformed version received"
 	exit 1
 fi	
 

--- a/version.sh
+++ b/version.sh
@@ -73,9 +73,8 @@ filename=$(h5ai_query "$component" "$distribution" "$channel" "$branch")
 currentVersion=$(version_from_filename "$filename")
 
 versiontemp="${currentVersion//[^.]}"
-
 # a valid version number has at least two dots. e.g. 1.2.3
-if [ $versiontemp -lt 2 ]; then
+if [ ${#versiontemp} -lt 2 ]; then
 	echo "Malformed version recieved"
 	exit 1
 fi	


### PR DESCRIPTION
Currently the kopano_core build fails when trying to push to the docker hub, because what is presented as the core version cannot be used for a tag. This change will already terminate the build before it started.