### PR TITLE
Changed gateway config to generated version

### DIFF
--- a/core/start-service.sh
+++ b/core/start-service.sh
@@ -154,7 +154,7 @@ gateway)
 		-timeout 360s
 	# cleaning up env variables
 	unset "${!KCCONF_@}"
-	exec "$EXE" -F
+	exec "$EXE" -c /tmp/kopano/gateway.cfg
 	;;
 ical)
 	dockerize \


### PR DESCRIPTION
The generated file /tmp/kopano/gateway.cfg was not used, just the read only one in /etc/.
The Foreground Flag (-F) seems not to apply to the executable aswell.

Fixes #412 