### PR TITLE
Fix core gateway start parameter

### DIFF
--- a/core/start-service.sh
+++ b/core/start-service.sh
@@ -154,7 +154,7 @@ gateway)
 		-timeout 360s
 	# cleaning up env variables
 	unset "${!KCCONF_@}"
-	exec "$EXE" -F
+	exec "$EXE" -c /tmp/kopano/gateway.cfg
 	;;
 ical)
 	dockerize \


### PR DESCRIPTION
gateway ignored generated config in /tmp/kopano/gateway.cfg and took it's default /etc/kopano/gateway.cfg

Fixes #413 