### PR TITLE
Added php-xml dependency for z-push

### DIFF
--- a/zpush/Dockerfile
+++ b/zpush/Dockerfile
@@ -46,12 +46,14 @@ RUN --mount=type=secret,id=repocred,target=/etc/apt/auth.conf.d/kopano.conf \
     set -x && \
     # TODO set IGNORE_FIXSTATES_ON_UPGRADE https://jira.z-hub.io/browse/ZP-1164
     # TODO remove php-mbstring once https://jira.z-hub.io/browse/ZP-1541 is resolved
+    # TODO remove php-xml once https://jira.z-hub.io/projects/ZP/issues/ZP-1558 is resolved
     apt-get update && apt-get install -y --no-install-recommends \
         apache2 \
         ca-certificates \
         crudini \
         libapache2-mod-php7.3 \
         php-mbstring \
+        php-xml \
         z-push-autodiscover \
         z-push-config-apache \
         z-push-config-apache-autodiscover \


### PR DESCRIPTION
Upstream report for z-push Debian packaging is issued, while it's not resolved an additional dependency.
Can be removed once https://jira.z-hub.io/projects/ZP/issues/ZP-1558 is fixed

Fixes #410 