### PR TITLE
remove kopano-cli from the tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Yes, that is certainly a possibility. Within the `examples/` directory you can f
 - Stop compose running in the background: `docker-compose stop`
 - Destroy local containers and network interfaces: `docker-compose down`
 - Destroy volumes as well (will completely reset the containers, **deletes all data**): `docker-compose down -v`
-- Run commands in a running container: `docker-compose exec kopano_server kopano-cli --list-users`
+- Run commands in a running container: `docker-compose exec kopano_server kopano-admin -l`
 - Get logs of a in the background running container: `docker-compose logs -f kopano_server`
 - Run a `kopano-backup`: `docker run --rm -it -v /var/run/kopano/:/var/run/kopano -v $(pwd):/kopano/path zokradonh/kopano_utils kopano-backup`
   - Same command but getting volumes from the existing `kopano_server` container: `docker run --rm -it --volumes-from kopano_server -v /root/kopano-backup:/kopano/path zokradonh/kopano_utils kopano-backup -h`

--- a/core/README.md
+++ b/core/README.md
@@ -33,11 +33,11 @@ e.g. `KCCOMMENT_LDAP_1=!include /usr/share/kopano/ldap.openldap.cfg`
 
 For core dumps on crashes kopano-server requires the `fs.suid_dumpable sysctl` to contain the value 2, not 0.
 
-It is recommended to sync the user list before the first login of a user. With the bundled ´docker-compose.yml´ the ´kopano_scheduler´ container will take care of this. Alternatively `kopano-cli --list-users` could be run once after initial install in the kopano_server container.
+It is recommended to sync the user list before the first login of a user. With the bundled ´docker-compose.yml´ the ´kopano_scheduler´ container will take care of this. Alternatively `kopano-admin --sync` could be run once after initial install in the kopano_server container.
 
 Example:
 
-`docker-compose exec kopano_server kopano-cli --list-users`
+`docker-compose exec kopano_server kopano-admin -l`
 
 Depending on the overall performance of the system and the amount of user the first execution of this command will take a moment before it produces any output. This is since this command kicks off the mailbox creation for the users.
 

--- a/tests/startup-test/test.sh
+++ b/tests/startup-test/test.sh
@@ -27,7 +27,6 @@ docker exec kopano_server goss -g /kopano/goss/server/goss.yaml validate
 docker exec kopano_server kopano-storeadm -h default: -P || true
 
 docker exec kopano_server kopano-admin --sync
-docker exec kopano_server kopano-cli --list-users
 docker exec kopano_server kopano-storeadm -O # list users without a store
 docker exec kopano_server kopano-admin -l
 docker exec kopano_zpush z-push-admin -a list


### PR DESCRIPTION
it has been removed in master and will no longer be part of kopano 10.x