### PR TITLE
Skip downloading of packages if folder already exists

### DIFF
--- a/base/create-kopano-repo.sh
+++ b/base/create-kopano-repo.sh
@@ -35,7 +35,7 @@ function dl_and_package_community {
 	channel=${3:-community}
 	branch=${4:-""}
 
-	if [ -d $component ]; then
+	if [ -d "$component" ]; then
 		echo "Packages have been downloaded in a previous stage. Skipping..."
 		return
 	fi

--- a/base/create-kopano-repo.sh
+++ b/base/create-kopano-repo.sh
@@ -35,6 +35,11 @@ function dl_and_package_community {
 	channel=${3:-community}
 	branch=${4:-""}
 
+	if [ -d $component ]; then
+		echo "Packages have been downloaded in a previous stage. Skipping..."
+		return
+	fi
+
 	# query community server by h5ai API
 	filename=$(h5ai_query "$component" "$distribution" "$channel" "$branch")
 	filename2=$(basename "$filename")


### PR DESCRIPTION
The base image is using onbuild instructions to reduce code duplication (in regards to fetching Kopano packages). Sadly the onbuild instructions are not only executed on the directly following container image, but in every image that is using the images from this project as a base.

Fixes https://github.com/zokradonh/kopano-docker/issues/430