### PR TITLE
Fix machine-id mount for spamd container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -533,7 +533,7 @@ services:
       - kopano_server
     volumes:
       - /etc/machine-id:/etc/machine-id
-      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id
+      - /etc/machine-id:/var/lib/dbus/machine-id
       - kopanosocket/:/run/kopano
       - kopanossl/:/kopano/ssl
       - kopanospamd/:/var/lib/kopano/spamd


### PR DESCRIPTION
When starting the whole kopano stack using `docker-compose up -d` the `kopano_spamd` fails to start because `/var/lib/dbus/machine-id` could not be found on my host system.
All other kopano containers instead define a mount of the host path `/etc/machine-id` to `/var/lib/dbus/machine-id`, so I assumed this is probably a copy/paste error or something. Changing the host path fixed my issue and caused the `kopano-spamd` container to successfully start. 