### PR TITLE
update docker-mailserver to 7.0.0

### DIFF
--- a/docker-compose.mail.yml
+++ b/docker-compose.mail.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   mail:
-    image: tvial/docker-mailserver:release-v7.0.0
+    image: tvial/docker-mailserver:release-v7.0.1
     restart: unless-stopped
     hostname: mail # hostname and domainname may need to be commented on some platforms (e.g. ChromeOS)
     domainname: ${LDAP_DOMAIN}

--- a/docker-compose.mail.yml
+++ b/docker-compose.mail.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   mail:
-    image: tvial/docker-mailserver:release-v6.2.0
+    image: tvial/docker-mailserver:release-v7.0.0
     restart: unless-stopped
     hostname: mail # hostname and domainname may need to be commented on some platforms (e.g. ChromeOS)
     domainname: ${LDAP_DOMAIN}
@@ -14,6 +14,7 @@ services:
     volumes:
       - maildata:/var/mail
       - mailstate:/var/mail-state
+      - maillogs:/var/log/mail
       - mtaconfig:/tmp/docker-mailserver/
     environment:
       - DMS_DEBUG=0
@@ -35,8 +36,8 @@ services:
       - ONE_DIR=1
       - PERMIT_DOCKER=connected-networks
       - POSTFIX_DAGENT=lmtp:kopano_dagent:2003
+      - PFLOGSUMM_TRIGGER=logrotate
       - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS}
-      - REPORT_RECIPIENT=1
       - SASLAUTHD_LDAP_BIND_DN=${LDAP_BIND_DN}
       - SASLAUTHD_LDAP_FILTER=${SASLAUTHD_LDAP_FILTER}
       - SASLAUTHD_LDAP_PASSWORD=${LDAP_BIND_PW}
@@ -45,6 +46,7 @@ services:
       - SASLAUTHD_MECHANISMS=rimap
       - SASLAUTHD_MECH_OPTIONS=kopano_gateway
       - SMTP_ONLY=1
+      - SPAMASSASSIN_SPAM_TO_INBOX=1
       - SSL_TYPE=self-signed
       - TZ=${TZ}
     env_file:
@@ -65,4 +67,5 @@ services:
 volumes:
   maildata:
   mailstate:
+  maillogs:
   mtaconfig:


### PR DESCRIPTION
Fixes #445 

## Proposed Changes
  - updated docker-mailserver image to 7.0.0
  - added volume for mail logs
  - use SPAMASSASSIN_SPAM_TO_INBOX to deliver spam to INBOX, upstreams new default is bouncing: https://github.com/tomav/docker-mailserver#spamassassin_spam_to_inbox
 - migrate REPORT_RECIPIENT to the new PFLOGSUMM_TRIGGER=logrotate

## Notes
- all REPORT_* options have been deprecated upstream and were split into PFLOGSUMM_* and LOGWATCH_* to allow individual configuration between pflogsum (postfix reports) and logwatch mail reports. The latter reports are new and disabled per default. I opted for migrating the options to PFLOGSUMM_* only to have the same behaviour as before. One might consider to enable logwatch reporting, too.
- the PFLOGSUMM_TRIGGER option does allow a new option "daily_cron" which creates report on a daily basis instead of a logrotating basis. This might be more accurate for some users, but I opted to keep the old behaviour which is encoded as "logrotate"
- we should consider setting POSTFIX_INET_PROTOCOLS to "ipv4" to allow running this container on non-ipv6-enabled hosts in a more secure manner: https://github.com/tomav/docker-mailserver/issues/1405#issuecomment-590106498 or https://github.com/tomav/docker-mailserver#permit_docker I cannot test the issue myself as my hosting provider is IPv4 only.