### PR TITLE
'Repair' ODT filepreviewer

### DIFF
--- a/webapp/kweb.cfg
+++ b/webapp/kweb.cfg
@@ -1,31 +1,29 @@
-:9080 {
-	log stdout
-	errors stderr
+:9080/webapp {
+    log stdout
+    errors stderr
 
-	# healthcheck
-	status 200 /status
+    root /usr/share/kopano-webapp/
+    fastcgi / /run/php/php-fpm-kopano-webapp.sock php {
+            root /usr/share/kopano-webapp/
+    }
 
-	alias /webapp/ /usr/share/kopano-webapp/
-	fastcgi2 /webapp/ /run/php/php-fpm-kopano-webapp.sock php {
-		without /webapp/
-		root /usr/share/kopano-webapp/
-	}
+    status 403 {
+            /config.php
+            /debug.php
+            /defaults.php
+            /init.php
+            /server
+            /version
 
-	status 403 {
-		/webapp/config.php
-		/webapp/debug.php
-		/webapp/defaults.php
-		/webapp/init.php
-		/webapp/server
-		/webapp/version
+            /plugins/forbidden
+    }
 
-		/webapp/plugins/forbidden
-	}
-
-	rewrite /webapp/plugins/ {
-		regexp config.php
-		to /webapp/plugins/forbidden
-	}
-
-	folderish /webapp
+    rewrite /plugins/ {
+            regexp config.php
+            to /plugins/forbidden
+    }
+}
+:9080/status {
+    # healthcheck
+    status 200 /
 }


### PR DESCRIPTION
Hi,

when i add the kopano-webapp-plugin-filepreviewer i was normaly able to view odt files inside the webapp. With the caddy/kwebd webserver i wasnt able to view odt files.
If the caddy webserver should serve a index.htm(l) file, its redirect to the directory thats hold the index.htm(l) file.
But with the fastcgi2 or alias module from kwebd this does not work, its generate a false redirect (pls see the issue in kweb github repo).
I change the config to use only buildin caddy modules and get the webapp+plugins to work.

Do you see any breaks in my config?

Fixes #

## Proposed Changes

  -
  -
  -
