### PR TITLE
default to Debian 10 for version.sh

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -18,7 +18,7 @@ trap finish EXIT
 source base/create-kopano-repo.sh
 
 component=${1:-core}
-distribution=${2:-Debian_9.0}
+distribution=${2:-Debian_10}
 channel=${3:-community}
 branch=${4:-""}
 


### PR DESCRIPTION
Files master is no longer published for Debian 9, which makes the test fail