### PR TITLE
BugFix Supported Build: Add mount of repository secrets in kdav

### DIFF
--- a/kdav/Dockerfile
+++ b/kdav/Dockerfile
@@ -30,7 +30,7 @@ LABEL maintainer=az@zok.xyz \
     org.label-schema.schema-version="1.0"
 
 # install Kopano kDAV
-RUN \
+RUN --mount=type=secret,id=repocred,target=/etc/apt/auth.conf.d/kopano.conf \
     set -x && \
     apt-get update && apt-get install -y --no-install-recommends \
         php-mbstring \


### PR DESCRIPTION
Fixes: Build fail of kopano_kdav image in supported mode.

https://github.com/zokradonh/kopano-docker/blob/89ccc1c4250098965d69b359c82798c36c0e1b22/kdav/Dockerfile#L35-L43
`apt-get update` tries to access kopano repositories and fails with `401`.

Mount of repocred is required despite the fact that no packages are installed from kopano on this stage.