### PR TITLE
Extract spamd-extras into separate extras and add documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -516,29 +516,6 @@ services:
     tmpfs:
       - /tmp
 
-  kopano_spamd:
-    image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
-    read_only: true
-    restart: unless-stopped
-    container_name: ${COMPOSE_PROJECT_NAME}_spamd
-    depends_on:
-      - kopano_server
-    volumes:
-      - /etc/machine-id:/etc/machine-id
-      - /etc/machine-id:/var/lib/dbus/machine-id
-      - kopanosocket/:/run/kopano
-      - kopanossl/:/kopano/ssl
-      - kopanospamd/:/var/lib/kopano/spamd
-    environment:
-      - SERVICE_TO_START=spamd
-      - TZ=${TZ}
-    env_file:
-      - kopano_spamd.env
-    networks:
-      - kopano-net
-    tmpfs:
-      - /tmp
-
 
 volumes:
   kdavstates:
@@ -546,7 +523,6 @@ volumes:
   kopanograpi:
   kopanolicenses:
   kopanosocket:
-  kopanospamd:
   kopanossl:
   kopanowebapp:
   web:

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ if [ ! -e /etc/machine-id ]; then
 fi
 
 echo "Creating individual env files for containers (if they do not exist already)"
-for dockerenv in ldap password-self-service mail db kopano_ssl kopano_server kopano_webapp kopano_zpush kopano_grapi kopano_kapi kopano_dagent kopano_spooler kopano_gateway kopano_ical kopano_monitor kopano_scheduler kopano_search kopano_konnect kopano_kwmbridge kopano_kwmserver kopano_meet kopano_kapps kopano_spamd; do
+for dockerenv in ldap password-self-service mail db kopano_ssl kopano_server kopano_webapp kopano_zpush kopano_grapi kopano_kapi kopano_dagent kopano_spooler kopano_gateway kopano_ical kopano_monitor kopano_scheduler kopano_search kopano_konnect kopano_kwmbridge kopano_kwmserver kopano_meet kopano_kapps; do
 	touch ./"$dockerenv".env
 done
 

--- a/spamd-extras/README.md
+++ b/spamd-extras/README.md
@@ -1,0 +1,31 @@
+# kopano-spamd extras for kopano-docker
+
+This directory contains a compose file including optional containers to enable learning spam to be used with the [SpamAssassin](https://spamassassin.apache.org/) bayes filter.
+
+## How to use this compose file?
+
+1. Add the `spamd-extras.yml` to the `COMPOSE_FILE` variable in your `.env` file.
+
+Example:
+
+```bash
+COMPOSE_FILE=docker-compose.yml:docker-compose.ports.yml:spamd-extras/spamd-extras.yml
+```
+
+2. Run `docker-compose up -d`.
+
+
+## kopano-spamd
+
+After startup there will be a new service `kopano-spamd` which will persist mails that are moved to `Junk` to a folder named `spam` inside the `kopanospamd` volume.
+Likewise mails that are moved from the `Junk` back to `Inbox` are persisted in `ham`. Both folders indicate mails that should be trained as either being ham or spam.
+
+The `kopano-scheduler` container is extended to run the training inside the `mail` docker container at about 4am with training results being picked up by SpamAssassin
+automatically. You can check the docker logs of the scheduler for the results of each run.
+
+While already trained files can be deleted immediately after each training run, there is no cleanup provided here. The `kopanospamd` volume will therefore grow over time.
+
+For the bayes filter to start working you will need to train at least 200 mails of each ham and spam. To create a set of initial data you can use the Kopano WebApp
+by selecting mails and using the `Export as` function to create a zip file of those mails and put them into the appropriate folder.
+
+Read more about how to create effective training data here: https://spamassassin.apache.org/full/3.4.x/doc/sa-learn.html#EFFECTIVE-TRAINING

--- a/spamd-extras/spamd-extras.yml
+++ b/spamd-extras/spamd-extras.yml
@@ -1,0 +1,37 @@
+version: "3.5"
+
+services:
+  kopano_spamd:
+    image: ${docker_repo:-zokradonh}/kopano_core:${CORE_VERSION:-latest}
+    read_only: true
+    restart: unless-stopped
+    container_name: ${COMPOSE_PROJECT_NAME}_spamd
+    depends_on:
+      - kopano_server
+      - mail
+    volumes:
+      - /etc/machine-id:/etc/machine-id
+      - /etc/machine-id:/var/lib/dbus/machine-id
+      - kopanosocket/:/run/kopano
+      - kopanossl/:/kopano/ssl
+      - kopanospamd/:/var/lib/kopano/spamd
+    environment:
+      - SERVICE_TO_START=spamd
+      - TZ=${TZ}
+      - KCCONF_SPAMD_SA_GROUP=kopano
+    networks:
+      - kopano-net
+    tmpfs:
+      - /tmp
+
+  mail:
+    volumes:
+      - kopanospamd/:/var/lib/kopano/spamd
+
+  kopano_scheduler:
+    environment:
+      - CRONDELAYED_LEARN_HAM=0 4 * * * docker exec kopano_mail sa-learn --spam /var/lib/kopano/spamd/spam --dbpath /var/mail-state/lib-amavis/.spamassassin
+      - CRONDELAYED_LEARN_SPAM=15 4 * * * docker exec kopano_mail sa-learn --ham /var/lib/kopano/spamd/ham --dbpath /var/mail-state/lib-amavis/.spamassassin
+
+volumes:
+  kopanospamd:


### PR DESCRIPTION
Signed-off-by: René Plötz <reneploetz@users.noreply.github.com>

Fixes #481

## Proposed Changes

  - added configuration & documentation for kopano-spamd
  - modify docker-compose to remove kopano_spamd

Note that removing kopano_spamd is technically a breaking change, albeit current users will either have properly configured it or will have a non-working component removed.